### PR TITLE
Checkout before publish. 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,4 +18,7 @@ workflows:
   version: 2
   build:
     jobs:
-      - publish
+      - publish:
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
Forgot to checkout code before publishing.
Without it when publishing we clear all the docs.