### PR TITLE
Pin the Stoplight CLI to ensure publishing continues to work.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - run:
           name: Publish to Stoplight
           command: |
-            npm install @stoplight/cli
+            npm install @stoplight/cli@3.0.4
             node ./node_modules/@stoplight/cli/bin/stoplight.js publish \
             --token ${STOPLIGHT_TOKEN} \
             --project gh/pagerduty/api-schema \


### PR DESCRIPTION
Our CI stopped working with the stoplight cli updated to a new major version. Pin to the last version that worked.