### PR TITLE
DEVI-990 - update deprecated circleci image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   publish:
     docker:
-      - image: cimg/node:fermium
+      - image: cimg/node:12.22.9
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   publish:
     docker:
-      - image: cimg/node:12.22.9
+      - image: cimg/node:16.13.2
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   publish:
     docker:
-      - image: circleci/node:erbium
+      - image: cimg/node:erbium
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   publish:
     docker:
-      - image: cimg/node:erbium
+      - image: cimg/node:fermium
     steps:
       - checkout
       - run:


### PR DESCRIPTION
DEVI-990 - https://pagerduty.atlassian.net/browse/DEVI-990
Slack post about deprecation and changed needed: https://pagerduty.slack.com/archives/C07Q87V3L/p1641339422441100

CircleCI released new images, and have deprecated old ones: https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034

Requires change to circleci config, to use next gen images going forward.

Test:

- [ ] Confirm builds works successfully