### PR TITLE
Incident_key is nullable for events triggered by Stackdriver

### DIFF
--- a/reference/REST/openapiv3.json
+++ b/reference/REST/openapiv3.json
@@ -2223,7 +2223,8 @@
         "in": "query",
         "description": "Incident de-duplication key. Incidents with child alerts do not have an incident key; querying by incident key will return incidents whose alerts have alert_key matching the given incident key.",
         "schema": {
-          "type": "string"
+          "type": "string",
+          "nullable": true
         }
       },
       "incident_services": {


### PR DESCRIPTION
Incidents triggered by Stackdriver GCP integration (using v1 events API) result in `incident.*` webhook events having a null incident_key.  

It's unclear if this schema definition needs to be updated, if there is bug in the events being emitted for this webhook, or if there is another cause of null incident_key in this scenario.  

This PR either fixes the schema or starts the conversation and hopefully leads to an answer